### PR TITLE
Pango's Text Attribute Markup's url is a dead link.

### DIFF
--- a/doc/en/how-to-make/theme.rd
+++ b/doc/en/how-to-make/theme.rd
@@ -39,7 +39,7 @@ page except the title page.
 
 You can set some properties by using
 (({prop_set})). ((<Pango Text Attribute
-Markup|URL:http://developer.gnome.org/doc/API/2.4/pango/PangoMarkupFormat.html>))
+Markup|URL:http://developer.gnome.org/pango/stable/PangoMarkupFormat.html>))
 has more information.
 
 : font_desc

--- a/doc/ja/how-to-make/theme.rd
+++ b/doc/ja/how-to-make/theme.rd
@@ -43,7 +43,7 @@ title: テーマの作り方
 
 (({prop_set}))では前景色（foreground）以外にも以下のものが指
 定できます．詳しくは((<Pango Text Attribute
-Markup|URL:http://developer.gnome.org/doc/API/2.4/pango/PangoMarkupFormat.html>))
+Markup|URL:http://developer.gnome.org/pango/stable/PangoMarkupFormat.html>))
 を見てください．
 
 : font_desc


### PR DESCRIPTION
I've found Pango's Text Attribute Markup is dead link in how-to-make/theme.rd. 
I fix this dead link url "http://developer.gnome.org/doc/API/2.4/pango/PangoMarkupFormat.html" to "http://developer.gnome.org/pango/stable/PangoMarkupFormat.html".

Please check the modification.
