### PR TITLE
Make <a> acceptable

### DIFF
--- a/lib/rabbit/parser/markdown/converter.rb
+++ b/lib/rabbit/parser/markdown/converter.rb
@@ -251,6 +251,12 @@ module Rabbit
             [Ext::TeX.make_image_by_LaTeX(src_file_path, {}, @canvas), {}]
           end
         end
+
+        def convert_a(element)
+          ref = ReferText.new(convert_container(element))
+          ref.to = element.attr['href']
+          ref
+        end
       end
     end
   end


### PR DESCRIPTION
こんにちは。

Markdownで書いている時に、リンクを含んでいると `rabbit` コマンドでエラーになっていました。
http://qiita.com/items/c892146aff09afe0a204

ツイッターで須藤さんにアドバイスいただいて、修正しました。ありがとうございました。

よければ取り込んでもらえると嬉しいです。
ご検討よろしくお願いします。
