### PR TITLE
allow to change alignment of preformatted text.

### DIFF
--- a/lib/rabbit/theme/default-preformatted/default-preformatted.rb
+++ b/lib/rabbit/theme/default-preformatted/default-preformatted.rb
@@ -12,10 +12,14 @@ if @preformatted_keep_in_size.nil?
   @preformatted_keep_in_size = true
 end
 
+if @preformatted_centering.nil?
+  @preformatted_centering = true
+end
+
 match("**", PreformattedBlock) do |blocks|
   name = "preformatted-block"
   
-  blocks.horizontal_centering = true
+  blocks.horizontal_centering = @preformatted_centering
 
   params = {
     :proc_name => name,


### PR DESCRIPTION
introduce @preformatted_centering into theme "default-preformatted".
- true: centering (default)
- false: left alignment

I hope rabbit to display preformatted text as left-alignment in some case.
