### PR TITLE
Fix slideshare_user

### DIFF
--- a/lib/rabbit/task/slide.rb
+++ b/lib/rabbit/task/slide.rb
@@ -157,8 +157,7 @@ module Rabbit
             publish_tasks << :rubygems
           end
 
-          slideshare_user = @slide.author.slideshare_user
-          if slideshare_user
+          if @slide.author.slideshare_user
             define_publish_slideshare_task
             publish_tasks << :slideshare
           end
@@ -179,6 +178,7 @@ module Rabbit
       end
 
       def define_publish_slideshare_task
+        slideshare_user = @slide.author.slideshare_user
         desc(_("Publish the slide to %s" % "SlideShare"))
         task :slideshare => [:pdf, "gem:validate"] do
           require "rabbit/slideshare"


### PR DESCRIPTION
2.0.3でrake publish:slideshareしたところ未定義変数エラーとなったので、
lib/rabbit/task/slide.rbを修正しました。

```
$ rake publish:slideshare
mkdir -p pdf
rake aborted!
undefined local variable or method `slideshare_user' for #<Rabbit::Task::Slide:0x9416708>

Tasks: TOP => publish:slideshare
(See full trace by running task with --trace)
```

ただ、ブラウザで開かれたURLが404エラーになってしまうようです。
数十分後にスライド一覧を確認したところ、アップロードには成功していました。
