### PR TITLE
slideshare: fix variable name

### DIFF
--- a/lib/rabbit/slideshare.rb
+++ b/lib/rabbit/slideshare.rb
@@ -61,14 +61,14 @@ module Rabbit
           return nil
         end
 
-        slide_url = nil
+        url = nil
         begin
-          sldie_url = slide_url(id)
+          url = slide_url(id)
         rescue Error
           @logger.error(_("Feailed to get slide URL: %s") % $!.message)
           return nil
         end
-        slide_url
+        url
       end
 
       private


### PR DESCRIPTION
Because overlapped with the method name.
It is slide url that get sllideshow.
### type

Bug
### version

2.0.6

2012-09-13のコミット(88f439dd9f4d6d303557514a7ff260134b3d10a1)で変数名とメソッド名が重複しており、get_slideshowしたURLが途中でnilになって、ブラウザで開く処理とconfig.yamlを更新する処理が動かなくなっていたので、変数名を修正しました。

変数名はスコープが狭いのと近くにslide_urlがあるので単にurlとしましたが、
同じクラスにAPIのURLもあるので少し曖昧でしょうかね…。
begin〜endで囲まれているので、一時変数をなくすのは抵抗がありました。

ログはこのように。いい感じのURLが表示されてはっぴーです。
ちなみに同じスライドを何回上げても成功しました。
ただ、なぜかStatusとだけ出ているinfoログが気になります。

```
% rake publish:slideshare
mkdir -p pdf
SlideShareのパスワードを入力してください [myokoym]:
[情報]
post https://www.slideshare.net/api/2/upload_slideshow
[情報]
Status
[情報]
get https://www.slideshare.net/api/2/get_slideshow?api_key=（省略）&slideshow_id=14452748 
[情報]
Status
[情報]
無事にアップロードできました！
[情報]
http://www.slideshare.net/myokoym/rabbit20-14452748を見てください
[情報]
ファイルを作成中:     ./config.yaml
```

あと、タイトルが日本語だけだと残念なURLになってしまうので、アップロードにはbase_nameを使い、あとからREADMEのタイトルに変更するようにできないかと思っています。
