### PR TITLE
slideshare: fix upload slide URL

### DIFF
--- a/lib/rabbit/task/slide.rb
+++ b/lib/rabbit/task/slide.rb
@@ -185,6 +185,7 @@ module Rabbit
           slideshare = SlideShare.new(@logger)
           slideshare.user = slideshare_user
           slideshare.pdf_path = pdf_path
+          slideshare.id = @slide.id
           slideshare.title = spec.summary
           slideshare.description = spec.description
           slideshare.tags = @tags if @tags


### PR DESCRIPTION
Change from README title to id (config.yaml) about slideshow title when upload slideshow.
Because slide URL was decided when uploaded slideshow title.
Edit slideshow title to README title after that.

昨日のPull Requestでお話しした、アップロード時のタイトルをidにする修正を実行に移しました。
APIは３回呼び出しており、順番は以下の通りです。editでもパスワードが必要ですが、入力は１回で済みます。
1. [upload_slideshow](http://www.slideshare.net/developers/documentation#upload_slideshow)
2. [edit_slideshow](http://www.slideshare.net/developers/documentation#edit_slideshow)
3. [get_slideshow](http://www.slideshare.net/developers/documentation#get_slideshow)

修正後のURLはこのようになります。
（ホスト名）/（ユーザー名）/（config.yamlのid）[-重複した場合は数値8桁がくっつく]

制約として、idにハイフン以外の記号が使われていると消えてしまいます。ハイフンに変換することは可能ですが、やっていません。

あと、SlideShareのURLのきまりかたについて少し調べてみました。きちんとしたリファレンスを見つけられればよかったのですが。
http://myokoym.github.com/entries/20120926/a0.html
