### PR TITLE
Support to embed a video into a slide page.

### DIFF
--- a/lib/rabbit/element/video.rb
+++ b/lib/rabbit/element/video.rb
@@ -1,0 +1,167 @@
+require "rabbit/utils"
+
+require "rabbit/image"
+require "rabbit/element"
+require "rabbit/parser/base"
+require "rabbit/video-window"
+
+module Rabbit
+  module Element
+    class Video
+      include Base
+      include BlockElement
+      include BlockHorizontalCentering
+      include TextRenderer
+
+      attr_reader :filename
+      attr_reader :normalized_width, :normalized_height
+      attr_reader :relative_width, :relative_height
+      attr_reader :relative_margin_top, :relative_margin_bottom
+      attr_reader :relative_margin_left, :relative_margin_right
+      attr_reader :relative_padding_top, :relative_padding_bottom
+      attr_reader :relative_padding_left, :relative_padding_right
+
+      def initialize(filename, prop)
+        @filename = filename
+        prop = Utils.stringify_hash_key(prop)
+        super()
+        normalized_prop = {}
+        prop.each do |name, value|
+          normalized_prop[name.gsub(/-/, '_')] = value
+        end
+        prop = normalized_prop
+        %w(as_large_as_possible).each do |name|
+          instance_variable_set("@#{name}", true_value?(prop[name]))
+        end
+        %w(width height
+           normalized_width normalized_height
+           relative_width relative_height
+           relative_margin_top relative_margin_bottom
+           relative_margin_left relative_margin_right
+           relative_padding_top relative_padding_bottom
+           relative_padding_left relative_padding_right
+          ).each do |name|
+          begin
+            instance_variable_set("@#{name}", prop[name] && Integer(prop[name]))
+          rescue ArgumentError
+            raise InvalidImageSizeError.new(filename, name, prop[name])
+          end
+        end
+
+        resize(@width, @height)
+      end
+
+      alias _compile compile
+      def compile_for_horizontal_centering(canvas, x, y, w, h)
+        _compile(canvas, x, y, w, h)
+      end
+
+      def compile(canvas, x, y, w, h)
+        super
+        adjust_size(canvas, @x, @y, @w, @h)
+      end
+
+      def width
+        @width.to_i + @padding_left + @padding_right
+      end
+
+      def height
+        @height.to_i + @padding_top + @padding_bottom
+      end
+
+      def as_large_as_possible?
+        @as_large_as_possible
+      end
+
+      def draw_element(canvas, x, y, w, h, simulation)
+        unless simulation
+          if canvas.display?
+            @video_window ||= VideoWindow.new(self)
+            @video_window.show(canvas.window)
+          else
+            draw_layout(canvas, x, y)
+          end
+        end
+        [x, y + height, w, h - height]
+      end
+
+      def text
+        "video : #{File.basename(@filename)}"
+      end
+
+      def to_rd
+        text
+      end
+
+      private
+      def adjust_margin(w, h)
+        @margin_top =
+          make_relative_size(@relative_margin_top, h) || @margin_top
+        @margin_bottom =
+          make_relative_size(@relative_margin_bottom, h) || @margin_bottom
+        @margin_left =
+          make_relative_size(@relative_margin_left, w) || @margin_left
+        @margin_right =
+          make_relative_size(@relative_margin_right, w) || @margin_right
+      end
+
+      def adjust_padding(w, h)
+        @padding_top =
+          make_relative_size(@relative_padding_top, h) || @padding_top
+        @padding_bottom =
+          make_relative_size(@relative_padding_bottom, h) || @padding_bottom
+        @padding_left =
+          make_relative_size(@relative_padding_left, w) || @padding_left
+        @padding_right =
+          make_relative_size(@relative_padding_right, w) || @padding_right
+      end
+
+      def adjust_size(canvas, x, y, w, h)
+        base_w = w
+        base_h = h
+        adjust_margin(base_w, base_h)
+        adjust_padding(base_w, base_h)
+        base_h = base_h - @padding_top - @padding_bottom
+        if @as_large_as_possible
+          iw = base_w
+          ih = base_h
+        else
+          nw = make_normalized_size(@normalized_width)
+          nh = make_normalized_size(@normalized_height)
+          rw = make_relative_size(@relative_width, base_w)
+          rh = make_relative_size(@relative_height, base_h)
+          iw = nw || rw || base_w
+          ih = nh || rh || base_h
+        end
+        resize(iw, ih)
+      end
+
+      def resize(w, h)
+        if w.nil? and h.nil?
+          return
+        else
+          w ||= width
+          h ||= height
+        end
+        w = w.ceil if w
+        h = h.ceil if h
+        if w and w > 0 and h and h > 0 and [w, h] != [width, height]
+          @width = w
+          @height = h
+        end
+      end
+
+      def make_normalized_size(size)
+        size && screen_size(size)
+      end
+
+      def make_relative_size(size, parent_size)
+        size && parent_size && ((size / 100.0) * parent_size).ceil
+      end
+
+      def true_value?(value)
+        value == true or value == "true"
+      end
+    end
+  end
+end

--- a/lib/rabbit/parser/ext/video.rb
+++ b/lib/rabbit/parser/ext/video.rb
@@ -1,0 +1,18 @@
+require 'rabbit/element'
+
+module Rabbit
+  module Parser
+    module Ext
+      module Video
+        def make_video(canvas, path, prop)
+          begin
+            Element::Video.new(path, prop)
+          rescue Error
+            canvas.logger.warn($!.message)
+            nil
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rabbit/parser/rd/ext/block-verbatim.rb
+++ b/lib/rabbit/parser/rd/ext/block-verbatim.rb
@@ -8,6 +8,7 @@ rescue LoadError
 end
 require 'rabbit/parser/rd/ext/base'
 require 'rabbit/parser/rd/ext/image'
+require 'rabbit/parser/rd/ext/video'
 require 'rabbit/parser/ext/enscript'
 require 'rabbit/parser/ext/tex'
 require 'rabbit/parser/ext/aafigure'
@@ -21,6 +22,7 @@ module Rabbit
       module Ext
         class BlockVerbatim < Base
           include Image
+          include Video
           include GetText
 
           def default_ext_block_verbatim(label, source, content, visitor)
@@ -58,6 +60,14 @@ module Rabbit
             else
               make_image(visitor, prop['src'], prop)
             end
+          end
+
+          def ext_block_verb_video(label, source, content, visitor)
+            return nil unless /^video$/i =~ label
+            src, prop = parse_source(source)
+            return nil if prop['src'].nil?
+
+            make_video(visitor, prop['src'], prop)
           end
 
           def ext_block_verb_enscript(label, source, content, visitor)

--- a/lib/rabbit/parser/rd/ext/video.rb
+++ b/lib/rabbit/parser/rd/ext/video.rb
@@ -1,0 +1,15 @@
+require 'rabbit/element'
+require 'rabbit/parser/ext/video'
+
+module Rabbit
+  module Parser
+    class RD
+      module Ext
+        module Video
+          include Parser::Ext::Video
+        end
+      end
+    end
+  end
+end
+

--- a/lib/rabbit/video-window.rb
+++ b/lib/rabbit/video-window.rb
@@ -1,0 +1,122 @@
+require 'gst'
+require 'gtk2'
+
+module Rabbit
+  class VideoWindow
+    attr_accessor :window, :direction, :entry
+    def initialize(element)
+      @element = element
+      @video = VideoWidget.new(@element.filename)
+    end
+
+    def setup(window)
+      if not @completed
+        @window = window
+        init_window
+        init_keys
+        @completed = true
+      end
+    end
+
+    def show(window)
+      setup(window) if not window.nil?
+      Utils.move_to(window, @video_window) do |bx, by, bw, bh, tw, th, sw, sh|
+        [bx+@element.x, by+@element.y]
+      end
+      @video_window.resize(@element.width, @element.height)
+      @video_window.show_all
+      @video.play
+    end
+
+    def hide
+      @video.pause
+      @video_window.hide
+    end
+
+    private
+    def init_window
+      @video_window = Gtk::Window.new(Gtk::Window::POPUP)
+      @video_window.modal = true
+      @video_window.set_transient_for(window)
+
+      vbox = Gtk::VBox.new
+      vbox.pack_start(@video)
+      @video_window.add(vbox)
+      @video_window.signal_connect('frame-event') do |widget, event|
+        if event.event_type == Gdk::Event::Type::BUTTON_PRESS
+          @video.toggle
+        end
+      end
+      @video_window.signal_connect('destroy') do
+        @video.stop
+      end
+    end
+
+    def init_keys
+      @video_window.signal_connect("key_press_event") do |widget, key|
+        case key.keyval
+        when Gdk::Keyval::GDK_KEY_space
+          @video.toggle
+        when Gdk::Keyval::GDK_KEY_plus
+          @video.seek(10)
+        when Gdk::Keyval::GDK_KEY_minus
+          @video.seek(-10)
+        when *[
+            Keys::MOVE_TO_NEXT_KEYS, Keys::MOVE_TO_PREVIOUS_KEYS,
+            Keys::MOVE_TO_LAST_KEYS, Keys::MOVE_TO_LAST_KEYS,
+          ].flatten
+          hide
+          Gtk::AccelGroup.activate(window, key.keyval, key.state)
+        else
+          Gtk::AccelGroup.activate(window, key.keyval, key.state)
+        end
+      end
+    end
+
+    class VideoWidget < Gtk::DrawingArea
+      def initialize(file)
+        super()
+
+        @playbin = Gst::ElementFactory.make('playbin2')
+
+        @video = Gst::ElementFactory.make('xvimagesink')
+        @video.force_aspect_ratio = true
+
+        @playbin.video_sink = @video
+        @playbin.audio_sink = Gst::ElementFactory.make('autoaudiosink')
+        @playbin.signal_connect('notify') do
+          @playbin.video_sink.xwindow_id = self.window.xid if self.window
+          @playbin.video_sink.expose
+        end
+        @playbin.uri = "file://#{File.absolute_path(file)}"
+        @playbin.ready
+      end
+
+      def play
+        @playbin.play
+        @playing = true
+      end
+
+      def pause
+        @playbin.pause
+        @playing = false
+      end
+
+      def stop
+        @playbin.stop
+        @playing = false
+      end
+
+      def seek(time)
+        @playbin.seek(1.0, Gst::Format::TIME,
+          Gst::Seek::FLAG_FLUSH | Gst::Seek::FLAG_KEY_UNIT,
+          Gst::Seek::TYPE_CUR, time * Gst::SECOND,
+          Gst::Seek::TYPE_NONE, -1);
+      end
+
+      def toggle
+        @playing ? pause : play
+      end
+    end
+  end
+end

--- a/rabbit.gemspec
+++ b/rabbit.gemspec
@@ -53,6 +53,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency("kramdown")
   spec.add_runtime_dependency("gettext")
   spec.add_runtime_dependency("faraday")
+  spec.add_runtime_dependency("gstreamer")
 
   spec.add_development_dependency("test-unit")
   spec.add_development_dependency("test-unit-notify")


### PR DESCRIPTION
RabbitにRuby/GStreamerの機能を使った動画再生機能を作ってみました。
以下のようなRDファイルでogg形式などのビデオが再生できます。

```
= Playing a video on Rabbit with GStreamer

: author
   Narihiro Nakamura
: theme
   lightning-talk

= begin

= ((' '))

  # video
  # src = /path/to/example.ogg

= end

```

(キーバインド: スペース=再生/Pause, -=巻き戻し, +=早送り)

現状ではRD形式にしか対応しておらず、Linux環境でしか試していません＞＜
