### PR TITLE
Update run-test.rb about add current directory to LOAD_PATH

### DIFF
--- a/test/run-test.rb
+++ b/test/run-test.rb
@@ -16,7 +16,7 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-base_dir = File.expand_path(".")
+base_dir = File.expand_path(File.join(File.dirname(__FILE__), ".."))
 $LOAD_PATH.unshift(base_dir)
 $LOAD_PATH.unshift(File.join(base_dir, "lib"))
 $LOAD_PATH.unshift(File.join(base_dir, "test"))


### PR DESCRIPTION
test/run-test.rb の LOAD_PATH にカレントディレクトリを追加してもいいでしょうか？

私の環境はシェルのPATHにカレントディレクトリを入れていないので、
テストを実行するときには -I オプションを付けなければ動きません。

```
% ruby -I . test/run-test.rb
```

この起動方法は一般的ですか？それとも別の起動方法があるのでしょうか。
私はオプション不要にしたいのですが、何か裏があるのかもと思い Pull Request してみました。
