### PR TITLE
Remove needless recheck of relative path for multibyte local file

### DIFF
--- a/lib/rabbit/parser/ext/image.rb
+++ b/lib/rabbit/parser/ext/image.rb
@@ -69,14 +69,7 @@ module Rabbit
           def local_path_to_image_filename(canvas, path)
             path = Pathname.new(GLib.filename_from_utf8(path))
             return path.to_s if path.absolute?
-
-            expanded_path = canvas.full_path(path.to_s)
-            expanded_uri = URI(expanded_path)
-            if expanded_uri.scheme.nil?
-              expanded_path
-            else
-              uri_to_image_filename(canvas, expanded_uri)
-            end
+            canvas.full_path(path.to_s)
           end
 
           def tmp_filename(canvas, key)


### PR DESCRIPTION
URIがパースされる箇所が残っていたので削除しました。

ただ、以下のコミットで追加されたようなのですが、理由がわかりませんでした。
必要なコードでしょうか？

7221b5cc0b98089697333bf8afa35e3834fc4f9f Support relative path for HTTP source 
