### PR TITLE
Fix relative local file path

### DIFF
--- a/lib/rabbit/parser/ext/image.rb
+++ b/lib/rabbit/parser/ext/image.rb
@@ -72,7 +72,7 @@ module Rabbit
 
             expanded_path = canvas.full_path(path.to_s)
             if start_with_scheme?(expanded_path)
-            uri_string_to_image_filename(canvas, expanded_path)
+              uri_string_to_image_filename(canvas, expanded_path)
             else
               expanded_path
             end


### PR DESCRIPTION
ローカルのRDファイルを相対パスで指定（rabbit sample/rabbit.rd）すると無限ループになっていたので、修正してみました。
（Canvas#full_pathは絶対パスを返すわけではないようです。。。）

レビューよろしくお願いいたします！
