### PR TITLE
Remove a needless locale_from_utf8 for help option

### DIFF
--- a/lib/rabbit/console.rb
+++ b/lib/rabbit/console.rb
@@ -200,7 +200,7 @@ module Rabbit
     def output_info_and_exit(options, message)
       if options.logger.is_a?(Logger::STDERR) and
           options.default_logger == options.logger
-        print(GLib.locale_from_utf8(message))
+        print(message)
       else
         options.logger.info(message)
       end


### PR DESCRIPTION
Because an encoding of the message is already locale encoding.

fixes [shocker-ja:1109]
