### PR TITLE
FIX: README.rd~ may be chosen when rake publish.

### DIFF
--- a/lib/rabbit/readme-parser.rb
+++ b/lib/rabbit/readme-parser.rb
@@ -31,7 +31,7 @@ module Rabbit
     end
 
     def parse(path=nil)
-      path ||= Dir.glob("README*")[0]
+      path ||= Dir.glob("README*").sort[0]
       raise _("No README found") if path.nil?
 
       parse_content(File.read(path))


### PR DESCRIPTION
When README.rd~ precedes README.rd and README.rd~ includes "TODO", an error occurs.
