### PR TITLE
Raise an exception if no screen is found

### DIFF
--- a/lib/rabbit/utils.rb
+++ b/lib/rabbit/utils.rb
@@ -353,6 +353,7 @@ module Rabbit
   module ScreenInfo
     module_function
     def default_screen
+      raise "No screen found. Is an X display available?" if Gdk::Screen.default.nil?
       Gdk::Screen.default
     end
     


### PR DESCRIPTION
This may alleviate some installation pain or remind users that a X display is required.

Addresses #31, but I'm not yet sure it actually _fixes_ it.
