### PR TITLE
Limit the amounts of tempfiles during slides execution

### DIFF
--- a/lib/rabbit/renderer/engine/cairo.rb
+++ b/lib/rabbit/renderer/engine/cairo.rb
@@ -492,11 +492,16 @@ module Rabbit
           context = ::Cairo::Context.new(surface)
           context.scale(width / dim.width, height / dim.height)
           context.render_rsvg_handle(handle)
-          png = Tempfile.new("rabbit-cairo-svg-renderer")
-          context.target.write_to_png(png.path)
-          context.target.finish
-          pixbuf = Gdk::Pixbuf.new(png.path)
-          _draw_reflected_pixbuf(pixbuf, x, y, params)
+          begin
+            png = Tempfile.new("rabbit-cairo-svg-renderer")
+            context.target.write_to_png(png.path)
+            context.target.finish
+            pixbuf = Gdk::Pixbuf.new(png.path)
+            _draw_reflected_pixbuf(pixbuf, x, y, params)
+          ensure
+            png.close
+            png.unlink
+          end
         end
 
         def set_line_options(params)


### PR DESCRIPTION
When allotted time is set some temp files are created, and in particular for slide with svg object inside (or any svg 'progress image') a TempFile is created for each object every 'timer value' (normally 5 sec). These files remain until 'Rabbit' is closed. This change wants to limit their growth during slides execution. 
