### PR TITLE
Add development devendency

### DIFF
--- a/rabbit.gemspec
+++ b/rabbit.gemspec
@@ -58,6 +58,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency("faraday")
   # spec.add_runtime_dependency("gstreamer")
 
+  spec.add_development_dependency("gtk3")
   spec.add_development_dependency("test-unit")
   spec.add_development_dependency("test-unit-notify")
   spec.add_development_dependency("test-unit-rr")


### PR DESCRIPTION
We can use gtk3 following command:

    $ bundle install --path vendor/bundle
    $ RABBIT_GTK_VERSION=3 bundle exec ruby bin/rabbit slide.rab