### PR TITLE
Use symbol for window type

### DIFF
--- a/lib/rabbit/frame.rb
+++ b/lib/rabbit/frame.rb
@@ -117,7 +117,7 @@ module Rabbit
 
     private
     def init_window(width, height, window_type=nil)
-      window_type ||= Gtk::Window::TOPLEVEL
+      window_type ||= :toplevel
       @window = Gtk::Window.new(window_type)
       @window.set_default_size(width, height)
       @window.parse_geometry(@geometry) if @geometry

--- a/lib/rabbit/progress.rb
+++ b/lib/rabbit/progress.rb
@@ -4,7 +4,7 @@ module Rabbit
   class Progress
     attr_reader :window, :foreground, :background
     def initialize
-      @window = Gtk::Window.new(Gtk::Window::POPUP)
+      @window = Gtk::Window.new(:popup)
       @window.app_paintable = true
       @bar = Gtk::ProgressBar.new
       @bar.show_text = true

--- a/lib/rabbit/search-window.rb
+++ b/lib/rabbit/search-window.rb
@@ -40,7 +40,7 @@ module Rabbit
 
     private
     def init_window
-      @window = Gtk::Window.new(Gtk::Window::POPUP)
+      @window = Gtk::Window.new(:popup)
       @window.modal = true
       init_frame
       init_box

--- a/lib/rabbit/video-window.rb
+++ b/lib/rabbit/video-window.rb
@@ -35,7 +35,7 @@ module Rabbit
 
     private
     def init_window
-      @video_window = Gtk::Window.new(Gtk::Window::POPUP)
+      @video_window = Gtk::Window.new(:popup)
       @video_window.modal = true
       @video_window.set_transient_for(window)
 


### PR DESCRIPTION
Suppress following message:

    lib/rabbit/progress.rb:7:in `initialize': 'Gtk::Window::POPUP' has been deprecated. Use 'Gtk::Window::Type::POPUP' or ':popup'.