### PR TITLE
Use Gdk::EventType::BUTTON* instead of Gdk::Event::BUTTON*

### DIFF
--- a/lib/rabbit/renderer/display/magnifier.rb
+++ b/lib/rabbit/renderer/display/magnifier.rb
@@ -33,7 +33,7 @@ module Rabbit
           @magnifier_center_y = nil
 
           target_button = 3
-          target_event_type = Gdk::Event::BUTTON_PRESS
+          target_event_type = Gdk::EventType::BUTTON_PRESS
           target_info = [target_button, target_event_type]
 
           add_button_press_hook do |event|

--- a/lib/rabbit/renderer/display/spotlight.rb
+++ b/lib/rabbit/renderer/display/spotlight.rb
@@ -33,7 +33,7 @@ module Rabbit
           @spotlight_center_y = nil
 
           target_button = 3
-          target_event_type = Gdk::Event::BUTTON2_PRESS
+          target_event_type = Gdk::EventType::BUTTON2_PRESS
           target_info = [target_button, target_event_type]
 
           add_button_press_hook do |event|


### PR DESCRIPTION
Because gdk3 defines Gdk::EventType::BUTTON* not Gdk::Event::BUTTON*.