### PR TITLE
Use Gdk::Window#{width,height} instead of Gdk::Window#size with index for gtk3

### DIFF
--- a/lib/rabbit/gtk.rb
+++ b/lib/rabbit/gtk.rb
@@ -29,6 +29,20 @@ module Gdk
     PROPAGATE = false unless const_defined?(:PROPAGATE)
   end
 
+  class Window
+    unless method_defined?(:width)
+      def width
+        size[0]
+      end
+    end
+
+    unless method_defined?(:height)
+      def height
+        size[1]
+      end
+    end
+  end
+
   unless const_defined?(:EventType)
     EventType = Event::Type
   end

--- a/lib/rabbit/renderer/display/base.rb
+++ b/lib/rabbit/renderer/display/base.rb
@@ -140,7 +140,8 @@ module Rabbit
         private
         def set_drawable(drawable)
           @drawable = drawable
-          w, h = @drawable.size
+          w = @drawable.width
+          h = @drawable.height
           @default_size_ratio = w.to_f / h.to_f
           @size_ratio = @default_size_ratio
           set_size(w, h)


### PR DESCRIPTION
This is the first step to replace Gdk::Window#size with Gdk::Window#{width,height}.
We may use Gdk::Window#size in other places.