### PR TITLE
Remove duplicate Dagger and dagger keys

### DIFF
--- a/lib/rabbit/parser/ext/entity.rb
+++ b/lib/rabbit/parser/ext/entity.rb
@@ -2405,8 +2405,6 @@ module Rabbit
           "copysr" => "&#x02117;",
           # =ballot cross
           "cross" => "&#x02717;",
-          # /ddagger B: =double dagger
-          "Dagger" => "&#x02021;",
           # /dagger B: =dagger
           "dagger" => "&#x02020;",
           # =hyphen (true graphic)

--- a/lib/rabbit/parser/ext/entity.rb
+++ b/lib/rabbit/parser/ext/entity.rb
@@ -2405,8 +2405,6 @@ module Rabbit
           "copysr" => "&#x02117;",
           # =ballot cross
           "cross" => "&#x02717;",
-          # /dagger B: =dagger
-          "dagger" => "&#x02020;",
           # =hyphen (true graphic)
           "dash" => "&#x02010;",
           # /diamondsuit =diamond suit symbol


### PR DESCRIPTION
Thank you for great presentation tool.

 I get this warnings when I run `rabbit` command.

 ```
/Users/naiad/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/rabbit-2.1.8/lib/rabbit/parser/ext/entity.rb:355: warning: duplicated key at line 2409 ignored: "Dagger"
/Users/naiad/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/rabbit-2.1.8/lib/rabbit/parser/ext/entity.rb:357: warning: duplicated key at line 2411 ignored: "dagger"
 ```