### PR TITLE
Use Utils.parse_four_way instead of Utils.parse_four_dimensions

### DIFF
--- a/lib/rabbit/command/rabbit.rb
+++ b/lib/rabbit/command/rabbit.rb
@@ -447,7 +447,7 @@ module Rabbit
                     Array,
                     _("Set page margin.")) do |margins|
             begin
-              top, right, bottom, left = Utils.parse_four_dimensions(margins)
+              top, right, bottom, left = Utils.parse_four_way(margins)
               options.page_margin_top = top
               options.page_margin_right = right
               options.page_margin_bottom = bottom


### PR DESCRIPTION
This will clear the error below that is raised when running `rabbit` with an option like `--page-margin=72,36`

```
[FATAL]
undefined method `parse_four_dimensions' for Rabbit::Utils:Module
```