### PR TITLE
Add Markdown file filter to choose dialog

### DIFF
--- a/lib/rabbit/command/rabbit.rb
+++ b/lib/rabbit/command/rabbit.rb
@@ -651,6 +651,7 @@ module Rabbit
         add_source_dialog_filter(dialog, "RD files", "*.rd")
         add_source_dialog_filter(dialog, "Hiki files", "*.hiki")
         add_source_dialog_filter(dialog, "PDF files", "*.pdf")
+        add_source_dialog_filter(dialog, "Markdown files", "*.md")
         add_source_dialog_filter(dialog, "All files", "*")
         file_name = nil
         if dialog.run == Gtk::Dialog::RESPONSE_ACCEPT


### PR DESCRIPTION
Rabbit has supported Markdown format since v1.0.5, 
but choose dialog hasn't supported Markdown file filter. I've fixed it.