### PR TITLE
Ignore horizontal rule

### DIFF
--- a/lib/rabbit/parser/markdown/converter.rb
+++ b/lib/rabbit/parser/markdown/converter.rb
@@ -261,6 +261,10 @@ module Rabbit
           end
         end
 
+        def convert_hr(element)
+          :no_element
+        end
+
         def convert_comment(element)
           :no_element
         end


### PR DESCRIPTION
When Rabbit read markdown file which includes horizontal rules, Rabbit was crashed by NoMethodError.
This is a test case.
```markdown
# Test

subtitle
:   Presentation with Markdown

author
:   Foo Bar

institution
:   COZMIXNG

theme
:   rabbit

# Page 1

A presentation tool

* A

---

* B
* C
```
This patch is workaround.
Rabbit will ignore horizontal rules, because Rabbit doesn't support it.