### PR TITLE
Raise ParseError if invalid item in list.

### DIFF
--- a/lib/rabbit/parser/markdown/converter.rb
+++ b/lib/rabbit/parser/markdown/converter.rb
@@ -172,6 +172,7 @@ module Rabbit
         end
 
         def create_list_item(list_item_class, contents)
+          raise ParseError,_("invalid item in list.")  unless contents.first.is_a?(Paragraph)
           list_item = list_item_class.new(contents)
 
           waited_paragraphs = list_item.elements.find_all do |element|


### PR DESCRIPTION
When markdown files contains wrong item in list, Rabbit reports NoMethodError.
I think it should report ParseError.

Example:
```
# Slide Page 1
* 
  1. abc
  2. def
* GHI
```
