### PR TITLE
fix margin handlings

### DIFF
--- a/lib/rabbit/renderer/display/magnifier.rb
+++ b/lib/rabbit/renderer/display/magnifier.rb
@@ -93,15 +93,17 @@ module Rabbit
 
           w = width / 1.5
           h = height / 1.5
-          x = @magnifier_center_x - w / 2
-          y = @magnifier_center_y - h / 2
+          center_x = @magnifier_center_x - size.logical_margin_left
+          center_y = @magnifier_center_y - size.logical_margin_top
+          x = center_x - w / 2
+          y = center_y - h / 2
           r = w * 0.1
           save_context do
             clip_block = Proc.new do
               draw_rectangle(true, 0, 0, width, height, @background)
-              translate_context(@magnifier_center_x, @magnifier_center_y)
+              translate_context(center_x, center_y)
               scale_context(@magnifier_ratio, @magnifier_ratio)
-              translate_context(-@magnifier_center_x, -@magnifier_center_y)
+              translate_context(-center_x, -center_y)
               block.call
             end
             draw_rounded_rectangle(false, x, y, w, h, r, nil,

--- a/lib/rabbit/renderer/display/spotlight.rb
+++ b/lib/rabbit/renderer/display/spotlight.rb
@@ -101,7 +101,7 @@ module Rabbit
               :color_stops => color_stops,
             }
           }
-          draw_rectangle(true, 0, 0, width, height, nil, params)
+          draw_rectangle(true, 0, 0, size.real_width, size.real_height, nil, params)
         end
 
         def spotlighting?


### PR DESCRIPTION
If Rabbit's window aspect ratio is not same as slide's one, there are two problems.

1. spotlight's background mask will not cover slide fullly
2. magnifier will not be displayed on cursor's position

This change should resolve those issues.