### PR TITLE
ファイル指定で markdown ファイルを開いたとき、情報ウィンドウのスライド表示が正しくない問題の修正

### DIFF
--- a/lib/rabbit/info-window.rb
+++ b/lib/rabbit/info-window.rb
@@ -301,6 +301,7 @@ module Rabbit
         @canvas.source_force_modified(true) do |original_source|
           source.source = original_source.read
           source.base = original_source.base
+          source.extension = original_source.extension
         end
         canvas.parse(source)
       end

--- a/lib/rabbit/source/memory.rb
+++ b/lib/rabbit/source/memory.rb
@@ -36,6 +36,8 @@ module Rabbit
       def reset
         @current_source = @original_source.dup
       end
+
+      attr_accessor :extension
     end
   end
 end


### PR DESCRIPTION
オリジナルのソースから情報ウィンドウへのソースにコピーする際、extension の情報が落ちるため、情報ウィンドウでのソースのパースが失敗します。

extension をコピーすることでこの問題を修正します。