### PR TITLE
Remove reference to "prototype.js" in doc

### DIFF
--- a/doc/en/index.rd
+++ b/doc/en/index.rd
@@ -158,10 +158,6 @@ or later. Kouhei Sutou can change the license of them. He considers
 that authors of them agree with the rule when they contribute their
 patches, codes and so on.
 
-lib/rabbit/div/prototype.js released under an MIT-style
-licence. For more information see ((<Prototype JavaScript
-Framework|URL:http://prototype.conio.net/>)).
-
 The author of
 data/rabbit/image/rubykaigi2011-images/rubykaigi2011-background-white.jpg
 and

--- a/doc/ja/index.rd
+++ b/doc/ja/index.rd
@@ -167,11 +167,6 @@ bin/rabbirc
 めて須藤がライセンスを変更できる権利を持つことに同意してもらったことと
 します。
 
-lib/rabbit/div/prototype.jsはMITスタイルのライセンスになりま
-す。
-詳しくは((<Prototype JavaScript
-Framework|URL:http://prototype.conio.net/>))を見てください。
-
 data/rabbit/image/rubykaigi2011-images/rubykaigi2011-background-white.jpg
 と
 data/rabbit/image/rubykaigi2011-images/rubykaigi2011-background-black.jpg


### PR DESCRIPTION
Because "prototype.js" is removed by 29330103.