### PR TITLE
Add support '--licenses' option in 'rabbit-slide new'

### DIFF
--- a/lib/rabbit/command/rabbit-slide.rb
+++ b/lib/rabbit/command/rabbit-slide.rb
@@ -135,6 +135,14 @@ module Rabbit
           @title = title
         end
 
+        parser.on("--licenses=LICENSE,LICENSE,...",
+                  Array,
+                  _("License of the new slide"),
+                  _("(e.g.: %s)") % _("--license=\"CC-BY-SA-4.0\""),
+                  _("(optional)")) do |licenses|
+          @slide_conf.licenses.concat(licenses)
+        end
+
         parser.on("--tags=TAG,TAG,...",
                   Array,
                   _("Tags of the new slide"),

--- a/po/en/rabbit.po
+++ b/po/en/rabbit.po
@@ -362,6 +362,12 @@ msgstr ""
 msgid "Tags of the new slide"
 msgstr ""
 
+msgid "License of the new slide"
+msgstr ""
+
+msgid "--license=\"CC-BY-SA-4.0\""
+msgstr ""
+
 msgid "Allotted time in presentaion"
 msgstr ""
 

--- a/po/fr/rabbit.po
+++ b/po/fr/rabbit.po
@@ -361,6 +361,12 @@ msgstr ""
 msgid "Tags of the new slide"
 msgstr ""
 
+msgid "License of the new slide"
+msgstr ""
+
+msgid "--license=\"CC-BY-SA-4.0\""
+msgstr ""
+
 msgid "Allotted time in presentaion"
 msgstr ""
 

--- a/po/ja/rabbit.po
+++ b/po/ja/rabbit.po
@@ -372,6 +372,12 @@ msgstr "--title=\"Rabbitの紹介\""
 msgid "Tags of the new slide"
 msgstr "新しいスライドのタグ"
 
+msgid "License of the new slide"
+msgstr "新しいスライドのライセンス"
+
+msgid "--license=\"CC-BY-SA-4.0\""
+msgstr ""
+
 msgid "Allotted time in presentaion"
 msgstr "プレゼンの持ち時間"
 


### PR DESCRIPTION
config yaml file that generated from `rabbit-slide new` has `licenses` field  but not support `--licenses` option in `rabbit-slide new`.