### PR TITLE
test/test-applier.rb#normalize_source requires keep option supported test/unit/data.

### DIFF
--- a/rabbit.gemspec
+++ b/rabbit.gemspec
@@ -81,7 +81,7 @@ can see your slide at https://slide.rabbit-shocker.org/ .
   # spec.add_runtime_dependency("gstreamer")
   spec.add_runtime_dependency("rouge")
 
-  spec.add_development_dependency("test-unit")
+  spec.add_development_dependency("test-unit", ">= 3.2.9")
   spec.add_development_dependency("test-unit-rr")
   spec.add_development_dependency("rake")
   spec.add_development_dependency("bundler")


### PR DESCRIPTION
Debian has only test-unit 3.2.8 currently and rabbit 3.0.0 has failed to test with test-unit 3.2.8:

```
/usr/lib/ruby/vendor_ruby/test/unit/data.rb:67:in `data': wrong number arguments(3 for 1..2) (ArgumentError)
	from /tmp/autopkgtest-lxc.rnohdrmy/downtmp/build.5Ts/real-tree/test/test-applier.rb:33:in `block in <class:RabbitApplierTest>'
	from /usr/lib/ruby/vendor_ruby/test/unit/testcase.rb:379:in `class_eval'
	from /usr/lib/ruby/vendor_ruby/test/unit/testcase.rb:379:in `sub_test_case'
	from /tmp/autopkgtest-lxc.rnohdrmy/downtmp/build.5Ts/real-tree/test/test-applier.rb:28:in `<class:RabbitApplierTest>'
	from /tmp/autopkgtest-lxc.rnohdrmy/downtmp/build.5Ts/real-tree/test/test-applier.rb:19:in `<top (required)>'
```

Rabbit 3.0.0's test/test-applier.rb#normalize_source requires keep option supported test/unit/data with test-unit >= 3.2.9.

* https://github.com/rabbit-shocker/rabbit/commit/668cea57cee7dd0fb8f311a17dd6644fa09395e6#diff-3bb1025c20a81d363e9d0ff668105007R33-R41
* https://github.com/test-unit/test-unit/commit/4c32174685568e135e815ea1d278b0635ccf26d8#diff-d36d0eabe966cc654cf457355995f946