### PR TITLE
fix an issue that Usa Taro will not reach the goal if you modify @margin_left

### DIFF
--- a/lib/rabbit/theme/image-slide-number/image-slide-number.rb
+++ b/lib/rabbit/theme/image-slide-number/image-slide-number.rb
@@ -88,7 +88,7 @@ match(Slide) do |slides|
       margin_bottom = @image_slide_number_margin_bottom || slide.margin_bottom
       base_x = margin_left
       base_y = canvas.height - loader.height - margin_bottom
-      max_width = canvas.width - margin_left - base_x - loader.width
+      max_width = canvas.width - margin_right - base_x - loader.width
       start_base_x = base_x
       goal_base_x = canvas.width - margin_right - goal_flag_width
 


### PR DESCRIPTION
I have set `@margin_left = 300` because my slide backgroung has black area on the left side (see below).

![rabbit-1](https://user-images.githubusercontent.com/8454208/68573010-25011200-04aa-11ea-99bf-b99dea23648e.png)

However, modifying `@margin_left` causes an issue that Usa Taro won't reach the goal (see below).

![rabbit-2](https://user-images.githubusercontent.com/8454208/68573087-5974ce00-04aa-11ea-9f50-95bda46cec0c.png)

My patch will fix this issue and work well even if you modify both `@margin_left` and `@margin_right`