### PR TITLE
Use URI.open

### DIFF
--- a/lib/rabbit/parser/ext/image.rb
+++ b/lib/rabbit/parser/ext/image.rb
@@ -109,7 +109,7 @@ module Rabbit
 
           def setup_image_file(canvas, uri, filename)
             begin
-              open(uri, "rb") do |in_file|
+              URI.open(uri, "rb") do |in_file|
                 File.open(filename, "wb") do |out|
                   out.print(in_file.read)
                 end


### PR DESCRIPTION
Suppress a error message.

```
rabbit/lib/rabbit/parser/ext/image.rb:112: warning: calling URI.open via Kernel#open is deprecated, call URI.open directly or use URI#open
```