### PR TITLE
Just exec "gem push" in `rake publish:rubygems`

### DIFF
--- a/lib/rabbit/gem-pusher.rb
+++ b/lib/rabbit/gem-pusher.rb
@@ -32,35 +32,7 @@ module Rabbit
     end
 
     def push
-      credentials_path = File.expand_path("~/.gem/credentials")
-      credentials_path_exist = File.exist?(credentials_path)
-      if credentials_path_exist
-        credentials = YAMLLoader.load(File.read(credentials_path))
-      else
-        credentials = {}
-      end
-      unless credentials.key?(@user.to_sym)
-        credentials[@user.to_sym] = retrieve_api_key
-        File.open(credentials_path, "w") do |credentials_file|
-          credentials_file.print(credentials.to_yaml)
-        end
-        unless credentials_path_exist
-          File.chmod(0600, credentials_path)
-        end
-      end
-      ruby("-S", "gem", "push", @gem_path,
-           "--key", @user)
-    end
-
-    private
-    def retrieve_api_key
-      prompt = _("Enter password on RubyGems.org [%{user}]: ") % {:user => @user}
-      reader = PasswordReader.new(prompt)
-      password = reader.read
-      open("https://rubygems.org/api/v1/api_key.yaml",
-           :http_basic_authentication => [@user, password]) do |response|
-        YAMLLoader.load(response.read)[:rubygems_api_key]
-      end
+      system("gem push #{@gem_path}")
     end
   end
 end

--- a/lib/rabbit/gem-pusher.rb
+++ b/lib/rabbit/gem-pusher.rb
@@ -26,9 +26,8 @@ module Rabbit
     include GetText
     include Rake::DSL
 
-    def initialize(gem_path, user)
+    def initialize(gem_path)
       @gem_path = gem_path
-      @user = user
     end
 
     def push

--- a/lib/rabbit/task/slide.rb
+++ b/lib/rabbit/task/slide.rb
@@ -176,7 +176,7 @@ module Rabbit
       def define_publish_rubygems_task
         desc(_("Publish the slide to %s") % "RubyGems.org")
         task :rubygems => :gem do
-          pusher = GemPusher.new(gem_path, @slide.author.rubygems_user)
+          pusher = GemPusher.new(gem_path)
           pusher.push
         end
       end

--- a/lib/rabbit/task/theme.rb
+++ b/lib/rabbit/task/theme.rb
@@ -172,7 +172,7 @@ module Rabbit
           if rubygems_user
             desc(_("Publish the theme to %s") % "RubyGems.org")
             task :rubygems => :gem do
-              pusher = GemPusher.new(gem_path, rubygems_user)
+              pusher = GemPusher.new(gem_path)
               pusher.push
             end
             publish_tasks << :rubygems


### PR DESCRIPTION
Previous implementation does not support MFA token input.

And `~/.gem/credentials` format was changed.

![image](https://user-images.githubusercontent.com/4487291/133085108-235596f0-f2c7-4ab4-b024-3da6107ee64e.png)

`gem` command know how to publish gem, so just exec that.

## after
![image](https://user-images.githubusercontent.com/4487291/133085180-17d08608-fc80-4692-add7-4b8679bae6bd.png)
