### PR TITLE
Add config 'source_code_uri'

### DIFF
--- a/lib/rabbit/slide-configuration.rb
+++ b/lib/rabbit/slide-configuration.rb
@@ -46,6 +46,7 @@ module Rabbit
     attr_accessor :author
     attr_accessor :width
     attr_accessor :height
+    attr_accessor :source_code_uri
     def initialize(logger=nil)
       @logger = logger || Logger.default
       clear
@@ -99,6 +100,7 @@ module Rabbit
       @author            = nil
       @width             = 800
       @height            = 600
+      @source_code_uri   = nil
     end
 
 
@@ -125,6 +127,7 @@ module Rabbit
 
       @width             = conf["width"]             || @width
       @height            = conf["height"]            || @height
+      @source_code_uri   = conf["source_code_uri"]   || @source_code_uri
     end
 
     def to_hash
@@ -143,6 +146,7 @@ module Rabbit
         "youtube_id"        => @youtube_id,
         "width"             => @width,
         "height"            => @height,
+        "source_code_uri"   => @source_code_uri,
       }
       config["author"] = @author.to_hash if @author
       config

--- a/lib/rabbit/task/slide.rb
+++ b/lib/rabbit/task/slide.rb
@@ -65,6 +65,7 @@ module Rabbit
           spec.summary = readme_parser.title || "TODO"
           spec.description = readme_parser.description || "TODO"
           spec.licenses = @slide.licenses
+          spec.metadata['source_code_uri'] = @slide.source_code_uri
 
           slide_conf_path = @slide.path
           spec.files = [".rabbit", slide_conf_path, "Rakefile"]


### PR DESCRIPTION
To refer to other presentation, it is useful to possible to read the source code of the presentation.
(I referred to hasmikin's code (rubykaigi 2021 takeout specific theme) in create my presentation when rubykaigi 2021 takeout.)

In a slide published on rubygems.org that has a specification "homepage" but it points uri of slide.rabbit-shocker.org.
Therefore, allow set metadata "source_code_uri" through config.yaml to easy to access the source code of the presentation.

You can confirm in this URL how it worked.
https://rubygems.org/gems/rabbit-slide-unasuke-rubykaigi-takeout-2021/versions/1.0.6

