### PR TITLE
Update install guide using Homebrew on macos

### DIFF
--- a/doc/en/install/homebrew.rd
+++ b/doc/en/install/homebrew.rd
@@ -2,38 +2,33 @@
 layout: en
 title: Install with Homebrew
 ---
-== How to install Rabbit with Homebrew on Mac OS X
+== How to install Rabbit with Homebrew on macOS
 
-This document describes how to install Rabbit with Homebrew and RubyGems on Mac OS X.
+This document describes how to install Rabbit with Homebrew and RubyGems on macOS.
 
 === Requirements
 
-* An Intel CPU
-* OS X Leopard or higher
+* A macOS machine
 * Xcode with X11 (XQuartz is required)
 
 === Install Homebrew
 
- $ ruby <(curl -fsSkL raw.github.com/mxcl/homebrew/go)
-
-Then add /usr/local/bin to your PATH.
+Follow the instruction on ((<URL:https://brew.sh>)).
 
 === Install softwares Rabbit needs
 
   $ brew install cairo
-  $ brew link cairo
-  $ brew link --overwrite pixman
   $ brew install pango
   $ brew install gtk+
-  $ brew install poppler --with-glib
-  $ brew install libsvg
+  $ brew install gobject-introspection
+  $ brew install poppler
 
 === Install Rabbit
 
 Exec gem install.
 
-  $ sudo PKG_CONFIG_PATH=/usr/local/opt/libffi/lib/pkgconfig gem install rabbit
-  $ sudo gem install rabbiter # If you want to use Twitter related features
+  $ gem install rabbit
+  $ gem install rabbiter # If you want to use Twitter related features
 
 === Set environment variable
 

--- a/doc/ja/install/homebrew.rd
+++ b/doc/ja/install/homebrew.rd
@@ -2,37 +2,33 @@
 layout: ja
 title: Homebrewでインストール
 ---
-== Mac OS XでHomebrewを使ったインストール方法
+== macOSでHomebrewを使ったインストール方法
 
-Mac OS X のパッケージ管理システムのひとつである Homebrew と RubyGems を利用して
+macOS のパッケージ管理システムのひとつである Homebrew と RubyGems を利用して
 Rabbit をインストール、利用する手順について説明します。
 
 === 事前に準備するもの
 
-* Intel Mac
-* Mac OS X Leopard 以上
+* macOS
 * Xcode と X11（XQuartzをインストール）
 
 === Homebrew のインストール
 
- $ ruby <(curl -fsSkL raw.github.com/mxcl/homebrew/go)
+((<URL:https://brew.sh/>)) に記載の方法に従ってインストールしてください。
 
-環境変数 PATH に /usr/local/bin を追加します。
-
-==== brew install と brew link の実行
+==== brew install の実行
 
   $ brew install cairo
-  $ brew link cairo
-  $ brew link --overwrite pixman
   $ brew install pango
   $ brew install gtk+
-  $ brew install poppler --with-glib
+  $ brew install gobject-introspection
+  $ brew install poppler
 
 === Rabbit のインストール
 
 gem install を実行します。
 
-  $ sudo PKG_CONFIG_PATH=/usr/local/opt/libffi/lib/pkgconfig gem install rabbit
+  $ sudo gem install rabbit
   $ sudo gem install rabbiter # Twitter連携機能を使う場合
 
 === 環境変数の設定


### PR DESCRIPTION
Homebrewを使用したインストール方法が色々と古くなっていたので現状に即した記述に更新しました。なお、パッケージにおいてはこれをインストールしていればとりあえず動いた、というのを確かめられただけで、これが最小構成かどうかの検証はできていません。