### PR TITLE
Update to installation guide for macOS with Homebrew

### DIFF
--- a/doc/en/install/homebrew.rd
+++ b/doc/en/install/homebrew.rd
@@ -19,7 +19,7 @@ Follow the instruction on ((<URL:https://brew.sh>)).
 
   $ brew install cairo
   $ brew install pango
-  $ brew install gtk+
+  $ brew install gtk+3
   $ brew install gobject-introspection
   $ brew install poppler
 
@@ -33,5 +33,4 @@ Exec gem install.
 === Set environment variable
 
 Add the following to your ~/.bach_login or ~/.zshenv:
-
-  export DYLD_LIBRARY_PATH=/usr/local/opt/cairo/lib
+  export DYLD_LIBRARY_PATH=$HOMEBREW_PREFIX/opt/cairo/lib

--- a/doc/ja/install/homebrew.rd
+++ b/doc/ja/install/homebrew.rd
@@ -20,7 +20,7 @@ Rabbit をインストール、利用する手順について説明します。
 
   $ brew install cairo
   $ brew install pango
-  $ brew install gtk+
+  $ brew install gtk+3
   $ brew install gobject-introspection
   $ brew install poppler
 
@@ -34,5 +34,4 @@ gem install を実行します。
 === 環境変数の設定
 
 ~/.bash_loginあるいは~/.zshenvで以下のようにDYLD_LIBRARY_PATH環境変数を設定します。
-
-  export DYLD_LIBRARY_PATH=/usr/local/opt/cairo/lib
+  export DYLD_LIBRARY_PATH=$HOMEBREW_PREFIX/opt/cairo/lib


### PR DESCRIPTION
macOSのHomebrewを使ったインストールのマニュアルについて、以下の２点をフォローしています。

* `brew install gtk+3` としないとGTK 3が入らなくてrabbitが動かないので、そのように変更しました。
* 環境によってHomebrewでインストールしたライブラリのPathが異なるので、環境に応じた`DYLD_LIBRARY_PATH`の設定ができるように記載を変更しました。