### PR TITLE
Fix document that default public level is all

### DIFF
--- a/doc/en/usage/rabbit.rd
+++ b/doc/en/usage/rabbit.rd
@@ -333,7 +333,7 @@ with the following.
    change-source, source and all. The later the public level
    indicates that Rabbit publishes more functions.
 
-   Default is strict.
+   Default is all.
 
 : --comment-source=FILE
    Specifies initial comment source file name.

--- a/doc/ja/usage/rabbit.rd
+++ b/doc/ja/usage/rabbit.rd
@@ -334,7 +334,7 @@ WindowsユーザならRDファイルをbin/rabbit.batにドラッグアンド
    change-source, source, allから選びます。後ろに挙げた公開
    レベルほど多くの機能を公開します。
 
-   デフォルトではstrictです。
+   デフォルトではallです。
 
 : --comment-source=FILE
    初期コメント用ソースのファイル名を指定します。


### PR DESCRIPTION
Since https://github.com/rabbit-shocker/rabbit/commit/77bc67542bb42256aae28f5ffb07ea2825183cf2