### PR TITLE
[Proposal] Add `rabbit-skip-print` metatag with description list

### DIFF
--- a/lib/rabbit/element/description-list.rb
+++ b/lib/rabbit/element/description-list.rb
@@ -18,12 +18,24 @@ module Rabbit
 
       attr_reader :term, :content
 
+      METADATA_LIST = {
+        "rabbit-skip-print" => -> (slide){ slide.skip_print }
+      }
+
       def initialize(term, content)
         super()
         @term = term
         @content = content
         add_element(@term)
         add_element(@content)
+      end
+
+      def metanize_if_metadata
+        term_text = term.map(&:text).join.strip
+        if METADATA_LIST.key?(term_text)
+          METADATA_LIST[term_text].call(slide)
+          parent.delete(self)
+        end
       end
     end
 

--- a/lib/rabbit/element/slide-element.rb
+++ b/lib/rabbit/element/slide-element.rb
@@ -10,6 +10,7 @@ module Rabbit
       def initialize(title_element)
         @index = -1
         @default_waited_draw_procs = []
+        @skip_print = false
         super(title_element)
       end
 
@@ -97,6 +98,14 @@ module Rabbit
           end
         end
         procs
+      end
+
+      def skip_print
+        @skip_print = true
+      end
+
+      def skip_print?
+        @skip_print
       end
 
       private

--- a/lib/rabbit/element/slide.rb
+++ b/lib/rabbit/element/slide.rb
@@ -46,6 +46,14 @@ module Rabbit
 
     class Body
       include ContainerElement
+
+      def <<(element)
+        super.tap do
+          if element.is_a?(DescriptionList)
+            element.each(&:metanize_if_metadata)
+          end
+        end
+      end
     end
   end
 end

--- a/lib/rabbit/renderer/base.rb
+++ b/lib/rabbit/renderer/base.rb
@@ -283,6 +283,7 @@ module Rabbit
         canceled = false
         @canvas.slides.each_with_index do |slide, i|
           @canvas.move_to_if_can(i)
+          next if @canvas.current_slide.skip_print?
           current_slide = @canvas.current_slide
           current_slide.flush
           current_slide.draw(@canvas)


### PR DESCRIPTION
I propose the `rabbit-skip-print` meta tag.

This meta tag behaves as if the meta tag does not exist when presentations,
and slides with the meta tag is omitted when printing.

When create slides, I often display items in stages. Display fewer items at the beginning and gradually increase them like an animation. The intention is to make it easier for people to pay attention to what I am saying.
For example:

```md
# title

  * list1

# title

  * list1
  * list2

# title

  * list1
  * list2
  * list3
```

However, when publishing slides on the Internet, this 'animation' is not necessary, and only the following slide is sufficient. Unlike during presentations, when reading slides on the Internet, readers can control page turning at their own timing.

```md
# title

  * list1
  * list2
  * list3
```

I can prepare a scenario for printing separately from the presentation scenario. However, since the presentation scenario is revised many times up until the presentation, the printed scenario also needs to be revised many times, which is a pain.
It would be better if the presentation and printed scenario use the same scenario but the output is different.
So I propose to introduce `rabbit-skip-print` meta tag so that the slides are displayed during the presentation but omitted when printed. What do you think about this?

---

E.g. following scenario converts next:

```md
# Title

# Body

  * list1

rabbit-skip-print
: skip-print

# Body

  * list1
  * list2
```

| | title | page 1 | page 2|
|--------|--------|--------| --- |
| **presentation** | ![title](https://github.com/user-attachments/assets/cb328e56-876e-4749-8e44-3a5ee47cf970) |![page1](https://github.com/user-attachments/assets/cd40e62d-4997-444c-9ce4-b56e18b6d30d)|![page2](https://github.com/user-attachments/assets/cc808c2c-3563-4a0b-928d-c61164368eb3)|
| **print** |<img alt="title" src="https://github.com/user-attachments/assets/479e6424-4c6d-40b3-a1d6-0d29a17bf6b5">|omitted |<img alt="page1" src="https://github.com/user-attachments/assets/a2607060-a433-43d7-a76c-9a7a8543efe5">| 
