### PR TITLE
Support original PDF

### DIFF
--- a/lib/rabbit/path-manipulatable.rb
+++ b/lib/rabbit/path-manipulatable.rb
@@ -33,5 +33,10 @@ module Rabbit
       Rabbit.logger.info(_("Creating file:      %s") % path)
       File.open(path, "w", &block)
     end
+
+    def copy_file(from, to)
+      Rabbit.logger.info("Copying file: #{from} to #{to}")
+      FileUtils.cp(from, to)
+    end
   end
 end

--- a/lib/rabbit/slide-configuration.rb
+++ b/lib/rabbit/slide-configuration.rb
@@ -46,6 +46,7 @@ module Rabbit
     attr_accessor :height
     attr_accessor :source_code_uri
     attr_writer :markup_language
+    attr_accessor :readme_markup_language
     def initialize
       clear
     end
@@ -100,6 +101,7 @@ module Rabbit
       @height            = 540
       @source_code_uri   = nil
       @markup_language   = nil
+      @readme_markup_language = nil
     end
 
 
@@ -128,6 +130,7 @@ module Rabbit
       @height            = conf["height"]            || @height
       @source_code_uri   = conf["source_code_uri"]   || @source_code_uri
       @markup_language   = conf["markup_language"]   || @markup_language
+      @readme_markup_language = conf["readme_markup_language"] || @readme_markup_language
     end
 
     def to_hash
@@ -148,6 +151,7 @@ module Rabbit
         "height"            => @height,
         "source_code_uri"   => @source_code_uri,
         "markup_language"   => @markup_language,
+        "readme_markup_language" => @readme_markup_language,
       }
       config["author"] = @author.to_hash if @author
       config
@@ -180,6 +184,10 @@ module Rabbit
 
     def markup_language
       @markup_language || @author.markup_language
+    end
+
+    def pdf_base_path
+      "#{@id}-#{@base_name}.pdf" 
     end
 
     private

--- a/lib/rabbit/task/slide.rb
+++ b/lib/rabbit/task/slide.rb
@@ -144,14 +144,18 @@ module Rabbit
       end
 
       def define_pdf_task
-        file pdf_path => [options_path, *(spec.files - [pdf_path])] do
-          mkdir_p(@pdf_dir)
-          rabbit("--print",
-                 "--output-filename", pdf_path)
+        if @slide.markup_language == :pdf
+          # Does nothing. Not list in "rake -T" but "rake pdf" is accepted..
+          task :pdf
+        else
+          file pdf_path => [options_path, *(spec.files - [pdf_path])] do
+            mkdir_p(@pdf_dir)
+            rabbit("--print",
+                   "--output-filename", pdf_path)
+          end
+          desc(_("Generate PDF: %{pdf_path}") % {:pdf_path => pdf_path})
+          task :pdf => pdf_path
         end
-
-        desc(_("Generate PDF: %{pdf_path}") % {:pdf_path => pdf_path})
-        task :pdf => pdf_path
       end
 
       def define_publish_task
@@ -197,11 +201,7 @@ module Rabbit
       end
 
       def pdf_path
-        File.join(@pdf_dir, pdf_base_path)
-      end
-
-      def pdf_base_path
-        "#{@slide.id}-#{@slide.base_name}.pdf"
+        File.join(@pdf_dir, @slide.pdf_base_path)
       end
 
       def homepage

--- a/test/test-slide-configuration.rb
+++ b/test/test-slide-configuration.rb
@@ -48,6 +48,7 @@ class TestSlideConfiguration < Test::Unit::TestCase
       "width"             => 800,
       "height"            => 600,
       "markup_language"   => "rd",
+      "readme_markup_language" => nil,
     }
     @slide.id = "RubyKaigi2012"
     @slide.merge!(conf)


### PR DESCRIPTION
Support original PDF

`:pdf` markup language already exists, but we couldn't use it to use original PDF.
This fix allows us to use `:pdf` markup language to use original PDF.

Points:

* Add `--readme-markup-language` to manage README format.
  * Use `:markdown` for `:pdf`.
  * Otherwise, use the same as `--markup-language` by default.
  * Backward compatible.
* The source file is `pdf/{id}-{base-name}.pdf`.
  * Copy the PDF file specified by the `--pdf` option at initialization.
* Skip `pdf` task to avoid unexpected PDF rebuild.

How to use:

1. `rabbit-slide new --id=foo --base_name=bar --markup-language=pdf --pdf=/path/to/pdf_file ...`
2. Write `README.md`.
3. Edit `config.yaml` if necessary.
4. You can run `rake` to show it or `rake publish` to publish it now.
